### PR TITLE
feat: split snapshot into multiple files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Latest Snapshot: testnet-geth-pbss-20241203.
 You can download the mainnet or testnet files separately in the list and unzip them in a same directory. Or you can use the following script:
 
 ```bash
+# install aria2 on your os
+yum install aria2
 wget https://raw.githubusercontent.com/bnb-chain/bsc-snapshots/main/dist/fetch-snapshot.sh
 
 # download & checksum the mainnet or testnet snapshot

--- a/README.md
+++ b/README.md
@@ -5,7 +5,58 @@ Currently, there are 3 sources of BSC snapshot could be used, if you are unclear
 ## Source-1: Legacy Full Node(~3TB)
 Usage: [usage/legacyfullnode_usage.md](./usage/legacyfullnode_usage.md)
 
-Endpoints:
+### mainnet(monthly update)
+
+Latest Snapshot: mainnet-geth-pbss-20241202.
+
+| file                                                                                                                                       | md5                              | size     |
+| ------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------- | -------- |
+| [mainnet-geth-pbss-blocks-10512000.tar.lz4](https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-10512000.tar.lz4) | 3a973854371e526be8dbbce63aad855b | 289.91GB |
+| [mainnet-geth-pbss-blocks-21024000.tar.lz4](https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-21024000.tar.lz4) | ef20506070cbe2deb3b0c3c5cae3149d | 601.39GB |
+| [mainnet-geth-pbss-blocks-31536000.tar.lz4](https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-31536000.tar.lz4) | 7ed223135e0bb50fdcf625529d89b83c | 376.89GB |       
+| [mainnet-geth-pbss-blocks-42048000.tar.lz4](https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-42048000.tar.lz4) | 6a21f55892f6da5f6ca5b77f6c0d88bd | 532.23GB |
+| [mainnet-geth-pbss-blocks-44431618.tar.lz4](https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-44431618.tar.lz4) | 87fe61c41ae62170c915e0f2ff649f62 | 106.09GB |     
+| [mainnet-geth-pbss-base-44521618.tar.lz4](https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-base-44521618.tar.lz4)     | 8afc09a4d44ba6041e2b666f97218700 | 869.10GB | 
+
+### testnet(update every 4 months)
+
+Latest Snapshot: testnet-geth-pbss-20241203.
+
+| file                                                                                                                                       | md5                              | size     |
+| ------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------- | -------- |
+| [testnet-geth-pbss-blocks-10512000.tar.lz4](https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-blocks-10512000.tar.lz4) | 5c4efc11b698d26f1c085b9b4796222d | 11.77GB  |
+| [testnet-geth-pbss-blocks-21024000.tar.lz4](https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-blocks-21024000.tar.lz4) | 7378acc5b51c52f34e4e02497c719804 | 35.94GB  |
+| [testnet-geth-pbss-blocks-31536000.tar.lz4](https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-blocks-31536000.tar.lz4) | 0428e85d9771a5664e0053305ec30e23 | 35.46GB  |
+| [testnet-geth-pbss-blocks-42048000.tar.lz4](https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-blocks-42048000.tar.lz4) | 60e1af49b60e23d795e5375b88b8a613 | 72.20GB  |
+| [testnet-geth-pbss-blocks-46068492.tar.lz4](https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-blocks-46068492.tar.lz4) | b7e4e24722a3ec91ade323673cfbe303 | 11.84GB  |
+| [testnet-geth-pbss-base-46158492.tar.lz4](https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-base-46158492.tar.lz4)     | 993e19a531f570bd0756fc6b8194e9ab | 111.27GB |
+
+### download
+
+You can download the mainnet or testnet files separately in the list and unzip them in a same directory. Or you can use the following script:
+
+```bash
+wget https://raw.githubusercontent.com/bnb-chain/bsc-snapshots/main/dist/fetch-snapshot.sh
+
+# download & checksum the mainnet or testnet snapshot
+bash fetch-snapshot.sh -d -c -D {download_dir} {mainnet-geth-pbss-20241202|testnet-geth-pbss-20241203}
+
+# extract the downloaded snapshot
+bash fetch-snapshot.sh -e -D {download_dir} -E {extract_dir} {mainnet-geth-pbss-20241202|testnet-geth-pbss-20241203}
+```
+
+You can remove the `-c` option to skip md5 checking. You can use help to get more detailed command parameters.
+
+```bash
+bash fetch-snapshot.sh --help
+# download, checksum, extract the snapshot, it need at least 6TB empty size for mainnet.
+bash fetch-snapshot.sh -d -e -c -D {download_dir} -E {extract_dir} {snapshot_name}
+# download, checksum, extract the snapshot, and auto delete the decompressed file, it need at least 4TB empty size for mainnet.
+bash fetch-snapshot.sh -d -e -c --auto-delete -D {download_dir} -E {extract_dir} {snapshot_name}
+```
+
+### Previous snapshot
+
 > - **mainnet(monthly)**: [geth-pbss-pebble-20241028.tar.lz4](https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/geth-pbss-pebble-20241028.tar.lz4)(md5: 50d63167e825a4e53258c4655d8ce040)
 > - **testnet(every 6 months)**: [testnet-geth-pbss-20240711.tar.lz4](https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-20240711.tar.lz4)(md5: 64626987189d739bd1a3ee743387f8a6)
 
@@ -17,3 +68,16 @@ Usage: [https://github.com/BNB48Club/bsc-snapshots](https://github.com/BNB48Club
 Usage: [usage/erigon3_archivenode_usage.md](./usage/erigon3_archivenode_usage.md), Erigon 3 release: [v1.3.0-alpha4](https://github.com/node-real/bsc-erigon/releases/tag/v1.3.0-alpha4)
 
 > Endpoints: Since Erigon 3, snapshot is no longer needed.
+
+## FAQ
+
+### Why split snapshot into multiple files?
+
+As the node snapshot of bsc becomes larger and larger, backup, upload and download will become increasingly unmaintainable, and it will occupy more disk space and take up more upload and download time.
+
+At the same time, in order to support the history expiry and state expiry of bsc later, it is planned to split the node snapshot according to historical data and active data, and the following advantages can be obtained:
+
+1. When updating the snapshot, only the changed part can be updated to reduce the difficulty of operation and maintenance;
+2. Support annual backup of historical data, which also helps with the subsequent historical data pruning;
+3. Support archiving multiple snapshot versions, avoiding wasting disk space;
+4. Support downloading and decompressing a single part immediately, and snapshot download and decompression can be completed on a smaller disk;

--- a/dist/fetch-snapshot.sh
+++ b/dist/fetch-snapshot.sh
@@ -1,0 +1,235 @@
+#!/bin/bash
+#set -v
+set -e
+
+handle_interrupt() {
+    echo "Exiting script..."
+    exit 1
+}
+trap handle_interrupt SIGINT
+
+show_help() {
+    echo "Usage: $0 [options] <CSV_FILE>"
+    echo "Options:"
+    echo "  -p, --prune-ancient    Skip files containing '-blocks-', and will support later"
+    echo "  -d, --download        Download files from CSV"
+    echo "  -e, --extract         Extract downloaded archives from CSV"
+    echo "  -c, --checksum        Verify MD5 checksums"
+    echo "  -C, --clean           Delete all files listed in the CSV"
+    echo "  -D, --download-dir <dir>  Set the download directory (default: .)"
+    echo "  -E, --extract-dir <dir>   Set the extract directory (default: same as download dir)"
+    echo "  -a, --auto-delete         Whether to auto delete downloaded file after uncompress"
+    echo "  -h, --help            Show this help message"
+}
+
+PRUNE_ANCIENT=false
+DOWNLOAD=false
+EXTRACT=false
+CHECKSUM=false
+CLEAN=false
+DOWNLOAD_DIR="./"
+EXTRACT_DIR="$DOWNLOAD_DIR"
+AUTO_DELETE=false
+
+# parse command line
+while [[ $# -gt 0 ]]; do
+    key="$1"
+    case $key in
+        -p|--prune-ancient)
+        PRUNE_ANCIENT=true
+        shift
+        ;;
+        -d|--download)
+        DOWNLOAD=true
+        shift
+        ;;
+        -e|--extract)
+        EXTRACT=true
+        shift
+        ;;
+        -c|--checksum)
+        CHECKSUM=true
+        shift
+        ;;
+        -C|--clean)
+        CLEAN=true
+        shift
+        ;;
+        -a|--auto-delete)
+        AUTO_DELETE=true
+        shift
+        ;;
+        -D|--download-dir)
+        if [ "$DOWNLOAD_DIR" == "$EXTRACT_DIR" ]; then
+          DOWNLOAD_DIR="$2"
+          EXTRACT_DIR="$2"
+        else
+          DOWNLOAD_DIR="$2"
+        fi
+        shift
+        shift
+        ;;
+        -E|--extract-dir)
+        EXTRACT_DIR="$2"
+        shift
+        shift
+        ;;
+        -h|--help)
+        show_help
+        exit 0
+        ;;
+        *)
+        CSV_FILE="$1"
+        shift
+        ;;
+    esac
+done
+
+#echo $PRUNE_ANCIENT $DOWNLOAD $EXTRACT $CHECKSUM $CLEAN $AUTO_DELETE $DOWNLOAD_DIR $EXTRACT_DIR
+
+if [[ "$PRUNE_ANCIENT" = true ]]; then
+    echo "--prune-ancient is not supported now..."
+    exit 1
+fi
+
+if [[ -z "$CSV_FILE" ]]; then
+    echo "Error: CSV file is required."
+    show_help
+    exit 1
+fi
+
+if [[ ! -f "$CSV_FILE" ]]; then
+    if [[ ! -f "$CSV_FILE.csv" ]]; then
+      remote_file=https://raw.githubusercontent.com/bnb-chain/bsc-snapshots/main/dist/$CSV_FILE.csv
+      echo "try to download $CSV_FILE.csv from $remote_file"
+      wget -O $CSV_FILE.csv $remote_file
+    fi
+    CSV_FILE=$CSV_FILE.csv
+fi
+
+mkdir -p "$DOWNLOAD_DIR"
+mkdir -p "$EXTRACT_DIR"
+
+if [[ "$DOWNLOAD" = true ]]; then
+    echo "download file into $DOWNLOAD_DIR ..."
+    while IFS=',' read -r filename url md5 size; do
+        # skip the title roe
+        [[ "$filename" == "filename" ]] && continue
+
+        download_path="$DOWNLOAD_DIR/$filename"
+
+        # check ancient block files
+        if [[ "$PRUNE_ANCIENT" = true && "$filename" == *"-blocks-"* ]]; then
+            echo "Skipping $filename - contains '-blocks-'"
+            continue
+        fi
+
+        downloaded=false
+        # check if the file has been downloaded
+        if [[ -f "$download_path" ]] && [[ ! -f "$download_path.aria2" ]]; then
+            if [[ "$CHECKSUM" = true ]]; then
+              echo "$md5 $download_path" | md5sum -c --quiet
+              if [[ $? -eq 0 ]]; then
+                  echo "Skipping $filename - already downloaded and verified"
+                  downloaded=true
+              else
+                  echo "Deleting $filename - MD5 mismatch or file corrupted"
+                  rm -f "$download_path"
+              fi
+            else
+              echo "Skipping $filename - already downloaded"
+              downloaded=true
+            fi
+        fi
+
+        if [[ "$downloaded" = false ]]; then
+          echo "Downloading $filename from $url"
+          aria2c -s14 -x14 -k100M --continue --dir="$DOWNLOAD_DIR" "$url"
+
+          if [[ $? -eq 0 ]]; then
+              if [[ "$CHECKSUM" = true ]]; then
+                echo "$md5 $download_path" | md5sum -c --quiet
+                if [[ $? -eq 0 ]]; then
+                    echo "Download and verification complete: $filename"
+                else
+                    echo "Download complete, but MD5 verification failed: $filename"
+                    exit 1
+                fi
+              else
+                echo "Download complete: $filename"
+              fi
+          else
+              echo "Error downloading $filename"
+          fi
+        fi
+
+        # if enable auto delete, just uncompress the file and delete
+        if [[ "$EXTRACT" = true && "$AUTO_DELETE" = true ]]; then
+          echo "Extracting $filename"
+          tar -I lz4 -xvf "$download_path" -C "$EXTRACT_DIR"
+          if [[ $? -eq 0 ]]; then
+              rm -f "$download_path"
+              echo "Extraction complete and removed: $filename"
+          else
+              echo "Error extracting $filename"
+              exit 1
+          fi
+        fi
+    done < "$CSV_FILE"
+fi
+
+if [[ "$EXTRACT" = true && "$AUTO_DELETE" = false ]]; then
+    echo "extract file into $EXTRACT_DIR..."
+    while IFS=',' read -r filename url md5 size; do
+        # skip the title row
+        [[ "$filename" == "filename" ]] && continue
+
+        # check ancient block files
+        if [[ "$PRUNE_ANCIENT" = true && "$filename" == *"-blocks-"* ]]; then
+            echo "Skipping $filename - contains '-blocks-'"
+            continue
+        fi
+
+        download_path="$DOWNLOAD_DIR/$filename"
+        extract_path="$EXTRACT_DIR/$filename"
+
+        if [[ ! -f "$download_path" ]]; then
+            echo "Error: $filename not found, skipping extraction"
+            exit 1
+        fi
+
+        if [[ "$CHECKSUM" = true && "$DOWNLOAD" = false ]]; then
+          echo "$md5 $download_path" | md5sum -c --quiet
+          if [[ $? -eq 0 ]]; then
+            echo "$filename - already downloaded and verified"
+          else
+            echo "Download complete, but MD5 verification failed: $filename"
+            exit 1
+          fi
+        fi
+
+        echo "Extracting $filename"
+        tar -I lz4 -xvf "$download_path" -C "$EXTRACT_DIR"
+
+        if [[ $? -eq 0 ]]; then
+            echo "Extraction complete: $filename"
+        else
+            echo "Error extracting $filename"
+            exit 1
+        fi
+    done < "$CSV_FILE"
+fi
+
+if [[ "$CLEAN" = true ]]; then
+    while IFS=',' read -r filename url md5 size; do
+        [[ "$filename" == "filename" ]] && continue
+
+        download_path="$DOWNLOAD_DIR/$filename"
+        extract_path="$EXTRACT_DIR/$filename"
+
+        if [[ -f "$download_path" ]]; then
+            echo "Deleting $filename"
+            rm -f "$download_path"
+        fi
+    done < "$CSV_FILE"
+fi

--- a/dist/mainnet-geth-pbss-20241202.csv
+++ b/dist/mainnet-geth-pbss-20241202.csv
@@ -1,0 +1,7 @@
+filename,URL,md5,size
+mainnet-geth-pbss-base-44521618.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-base-44521618.tar.lz4,8afc09a4d44ba6041e2b666f97218700,869.10GB
+mainnet-geth-pbss-blocks-21024000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-21024000.tar.lz4,ef20506070cbe2deb3b0c3c5cae3149d,601.39GB
+mainnet-geth-pbss-blocks-42048000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-42048000.tar.lz4,6a21f55892f6da5f6ca5b77f6c0d88bd,532.23GB
+mainnet-geth-pbss-blocks-31536000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-31536000.tar.lz4,7ed223135e0bb50fdcf625529d89b83c,376.89GB
+mainnet-geth-pbss-blocks-10512000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-10512000.tar.lz4,3a973854371e526be8dbbce63aad855b,289.91GB
+mainnet-geth-pbss-blocks-44431618.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-44431618.tar.lz4,87fe61c41ae62170c915e0f2ff649f62,106.09GB

--- a/dist/testnet-geth-pbss-20241203.csv
+++ b/dist/testnet-geth-pbss-20241203.csv
@@ -1,0 +1,7 @@
+filename,URL,md5,size
+testnet-geth-pbss-base-46158492.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-base-46158492.tar.lz4,993e19a531f570bd0756fc6b8194e9ab,111.27GB
+testnet-geth-pbss-blocks-42048000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-blocks-42048000.tar.lz4,60e1af49b60e23d795e5375b88b8a613,72.20GB
+testnet-geth-pbss-blocks-21024000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-blocks-21024000.tar.lz4,7378acc5b51c52f34e4e02497c719804,35.94GB
+testnet-geth-pbss-blocks-31536000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-blocks-31536000.tar.lz4,0428e85d9771a5664e0053305ec30e23,35.46GB
+testnet-geth-pbss-blocks-46068492.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-blocks-46068492.tar.lz4,b7e4e24722a3ec91ade323673cfbe303,11.84GB
+testnet-geth-pbss-blocks-10512000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-blocks-10512000.tar.lz4,5c4efc11b698d26f1c085b9b4796222d,11.77GB


### PR DESCRIPTION
This PR will split the snapshot into multiple files, and provide a script to download & extract snapshot.

### Why split snapshot into multiple files?

As the node snapshot of bsc becomes larger and larger, backup, upload and download will become increasingly unmaintainable, and it will occupy more disk space and take up more upload and download time.

At the same time, in order to support the history expiry and state expiry of bsc later, it is planned to split the node snapshot according to historical data and active data, and the following advantages can be obtained:

1. When updating the snapshot, only the changed part can be updated to reduce the difficulty of operation and maintenance;
2. Support annual backup of historical data, which also helps with the subsequent historical data pruning;
3. Support archiving multiple snapshot versions, avoiding wasting disk space;
4. Support downloading and decompressing a single part immediately, and snapshot download and decompression can be completed on a smaller disk;