### PR TITLE
update: add latest mainnet snapshot;

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Usage: [usage/legacyfullnode_usage.md](./usage/legacyfullnode_usage.md)
 
 | Snapshot Type   | Snapshot File                                                                               | Total Size | Remark        |
 |-----------------|---------------------------------------------------------------------------------------------|------------|---------------|
-| Full Snapshot   | [mainnet-geth-pbss-20250208](dist/mainnet-geth-pbss-20250208.csv)                           | **~3TB**   |               |
-| Pruned Snapshot | [mainnet-geth-pbss-20250208-pruneancient](dist/mainnet-geth-pbss-20250208-pruneancient.csv) | **~900GB** | BSC >= v1.5.5 |
+| Full Snapshot   | [mainnet-geth-pbss-20250310](dist/mainnet-geth-pbss-20250310.csv)                           | **~3TB**   |               |
+| Pruned Snapshot | [mainnet-geth-pbss-20250310-pruneancient](dist/mainnet-geth-pbss-20250310-pruneancient.csv) | **~900GB** | BSC >= v1.5.5 |
 
 ### testnet(update every 4 months)
 
@@ -32,12 +32,12 @@ yum install aria2
 wget https://raw.githubusercontent.com/bnb-chain/bsc-snapshots/main/dist/fetch-snapshot.sh
 
 # download & checksum the mainnet or testnet snapshot
-bash fetch-snapshot.sh -d -c -D {download_dir} {mainnet-geth-pbss-20250208|testnet-geth-pbss-20241203}
+bash fetch-snapshot.sh -d -c -D {download_dir} {mainnet-geth-pbss-2025310|testnet-geth-pbss-20241203}
 # download & checksum the pruned mainnet or testnet snapshot
 bash fetch-snapshot.sh -d -c -p -D {download_dir} {mainnet-geth-pbss-20250208}
 
 # extract the downloaded snapshot
-bash fetch-snapshot.sh -e -D {download_dir} -E {extract_dir} {mainnet-geth-pbss-20250208|testnet-geth-pbss-20241203}
+bash fetch-snapshot.sh -e -D {download_dir} -E {extract_dir} {mainnet-geth-pbss-20250310|testnet-geth-pbss-20241203}
 ```
 
 You can remove the `-c` option to skip md5 checking. You can use help to get more detailed command parameters.
@@ -57,6 +57,7 @@ bash fetch-snapshot.sh -d -e -c -p --auto-delete -D {download_dir} -E {extract_d
 ### Previous snapshot
 
 - **mainnet**:
+  - [mainnet-geth-pbss-20250208](dist/mainnet-geth-pbss-20250208.csv), [mainnet-geth-pbss-20250208-pruneancient](dist/mainnet-geth-pbss-20250208-pruneancient.csv)
   - [mainnet-geth-pbss-20250104](dist/mainnet-geth-pbss-20250104.csv)
   - [mainnet-geth-pbss-20241202](dist/mainnet-geth-pbss-20241202.csv)
   - [geth-pbss-pebble-20241028.tar.lz4](https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/geth-pbss-pebble-20241028.tar.lz4)(md5: 50d63167e825a4e53258c4655d8ce040)

--- a/dist/mainnet-geth-pbss-20250310-pruneancient.csv
+++ b/dist/mainnet-geth-pbss-20250310-pruneancient.csv
@@ -1,0 +1,3 @@
+filename,URL,md5,size
+mainnet-geth-pbss-base-47342362.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-base-47342362.tar.lz4,e7a362cf71ae2b3faafb2de357d33d65,908.63GB
+mainnet-geth-pbss-blocks-pruneancient-47252362.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-pruneancient-47252362.tar.lz4,31c29f1f5dda061cbf2c916fcf205fba,0.00GB

--- a/dist/mainnet-geth-pbss-20250310.csv
+++ b/dist/mainnet-geth-pbss-20250310.csv
@@ -1,0 +1,7 @@
+filename,URL,md5,size
+mainnet-geth-pbss-base-47342362.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-base-47342362.tar.lz4,e7a362cf71ae2b3faafb2de357d33d65,908.63GB
+mainnet-geth-pbss-blocks-21024000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-21024000.tar.lz4,ef20506070cbe2deb3b0c3c5cae3149d,601.39GB
+mainnet-geth-pbss-blocks-42048000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-42048000.tar.lz4,6a21f55892f6da5f6ca5b77f6c0d88bd,532.23GB
+mainnet-geth-pbss-blocks-31536000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-31536000.tar.lz4,7ed223135e0bb50fdcf625529d89b83c,376.89GB
+mainnet-geth-pbss-blocks-10512000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-10512000.tar.lz4,3a973854371e526be8dbbce63aad855b,289.91GB
+mainnet-geth-pbss-blocks-47252362.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-47252362.tar.lz4,bd43aabed863166c884f1e176ded967b,240.18GB


### PR DESCRIPTION
Hi, this PR will update latest mainnet snapshot that pack in 20250208.

It provides full snapshot & pruned snapshot too.

| Snapshot Type   | Snapshot File                                                                               | Total Size | Remark        |
|-----------------|---------------------------------------------------------------------------------------------|------------|---------------|
| Full Snapshot   | [mainnet-geth-pbss-20250208](dist/mainnet-geth-pbss-20250208.csv)                           | **~3TB**   |               |
| Pruned Snapshot | [mainnet-geth-pbss-20250208-pruneancient](dist/mainnet-geth-pbss-20250208-pruneancient.csv) | **~900GB** | BSC >= v1.5.5 |