### PR TITLE
update: add latest testnet snapshot;

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ bash fetch-snapshot.sh -d -e -c -p --auto-delete -D {download_dir} -E {extract_d
   - [mainnet-geth-pbss-20241202](dist/mainnet-geth-pbss-20241202.csv)
   - [geth-pbss-pebble-20241028.tar.lz4](https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/geth-pbss-pebble-20241028.tar.lz4)(md5: 50d63167e825a4e53258c4655d8ce040)
 - **testnet**:
-  - [testnet-geth-pbss-20241203](dist/testnet-geth-pbss-20241203.csv)
   - [testnet-geth-pbss-20250321](https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-20250321.tar.lz4)
   - [testnet-geth-pbss-20240711.tar.lz4](https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-20240711.tar.lz4)(md5: 64626987189d739bd1a3ee743387f8a6)
+  - [testnet-geth-pbss-20241203](dist/testnet-geth-pbss-20241203.csv)
 
 ## Source-2: Pruned FullNode(~900GB) & FastNode(~300GB) By 48Club
 Usage: [https://github.com/BNB48Club/bsc-snapshots](https://github.com/BNB48Club/bsc-snapshots)

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Usage: [usage/legacyfullnode_usage.md](./usage/legacyfullnode_usage.md)
 
 ### testnet(update every 4 months)
 
-| Snapshot Type | Snapshot File                                                     | Total Size | Remark |
-|---------------|-------------------------------------------------------------------|------------|--------|
-| Full Snapshot | [testnet-geth-pbss-20241203](dist/testnet-geth-pbss-20241203.csv) | **~300GB** |        |
-| Full Snapshot | [testnet-geth-pbss-20250321](https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-20250321.tar.lz4) | **~320GB** |   this is the latest testnet snapshot in one file <br> md5: 34b7a23589c654700252320c65e05285 |
+| Snapshot Type   | Snapshot File                                                                               | Total Size | Remark        |
+|-----------------|---------------------------------------------------------------------------------------------|------------|---------------|
+| Full Snapshot   | [testnet-geth-pbss-20250407](dist/testnet-geth-pbss-20250407.csv)                           | **~300GB** |               |
+| Pruned Snapshot | [testnet-geth-pbss-20250407-pruneancient](dist/testnet-geth-pbss-20250407-pruneancient.csv) | **~120GB** | BSC >= v1.5.5 |
 
 ### Download
 
@@ -33,12 +33,12 @@ yum install aria2
 wget https://raw.githubusercontent.com/bnb-chain/bsc-snapshots/main/dist/fetch-snapshot.sh
 
 # download & checksum the mainnet or testnet snapshot
-bash fetch-snapshot.sh -d -c -D {download_dir} {mainnet-geth-pbss-2025310|testnet-geth-pbss-20241203}
+bash fetch-snapshot.sh -d -c -D {download_dir} {mainnet-geth-pbss-20250404|testnet-geth-pbss-20250407}
 # download & checksum the pruned mainnet or testnet snapshot
 bash fetch-snapshot.sh -d -c -p -D {download_dir} {mainnet-geth-pbss-20250208}
 
 # extract the downloaded snapshot
-bash fetch-snapshot.sh -e -D {download_dir} -E {extract_dir} {mainnet-geth-pbss-20250310|testnet-geth-pbss-20241203}
+bash fetch-snapshot.sh -e -D {download_dir} -E {extract_dir} {mainnet-geth-pbss-20250404|testnet-geth-pbss-20250407}
 ```
 
 You can remove the `-c` option to skip md5 checking. You can use help to get more detailed command parameters.
@@ -64,6 +64,8 @@ bash fetch-snapshot.sh -d -e -c -p --auto-delete -D {download_dir} -E {extract_d
   - [mainnet-geth-pbss-20241202](dist/mainnet-geth-pbss-20241202.csv)
   - [geth-pbss-pebble-20241028.tar.lz4](https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/geth-pbss-pebble-20241028.tar.lz4)(md5: 50d63167e825a4e53258c4655d8ce040)
 - **testnet**:
+  - [testnet-geth-pbss-20241203](dist/testnet-geth-pbss-20241203.csv)
+  - [testnet-geth-pbss-20250321](https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-20250321.tar.lz4)
   - [testnet-geth-pbss-20240711.tar.lz4](https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-20240711.tar.lz4)(md5: 64626987189d739bd1a3ee743387f8a6)
 
 ## Source-2: Pruned FullNode(~900GB) & FastNode(~300GB) By 48Club

--- a/dist/testnet-geth-pbss-20250407-pruneancient.csv
+++ b/dist/testnet-geth-pbss-20250407-pruneancient.csv
@@ -1,0 +1,3 @@
+filename,URL,md5,size
+testnet-geth-pbss-base-49756165.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-base-49756165.tar.lz4,a6ed0252303b3a18feac05ddd44d2c77,118.35GB
+testnet-geth-pbss-blocks-pruneancient-49666165.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-blocks-pruneancient-49666165.tar.lz4,101fff56cecdf743997c9608d166956c,0.00GB

--- a/dist/testnet-geth-pbss-20250407-pruneancient.csv
+++ b/dist/testnet-geth-pbss-20250407-pruneancient.csv
@@ -1,3 +1,3 @@
 filename,URL,md5,size
-testnet-geth-pbss-base-49756165.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-base-49756165.tar.lz4,a6ed0252303b3a18feac05ddd44d2c77,118.35GB
-testnet-geth-pbss-blocks-pruneancient-49666165.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-blocks-pruneancient-49666165.tar.lz4,101fff56cecdf743997c9608d166956c,0.00GB
+testnet-geth-pbss-base-49772226.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-base-49772226.tar.lz4,eb3fb6eea86f8f09b9a4f0728f944b56,118.62GB
+testnet-geth-pbss-blocks-pruneancient-49682226.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-blocks-pruneancient-49682226.tar.lz4,61012f8af4ccb5e8ad68aed3ca92c9c5,0.00GB

--- a/dist/testnet-geth-pbss-20250407.csv
+++ b/dist/testnet-geth-pbss-20250407.csv
@@ -1,7 +1,7 @@
 filename,URL,md5,size
-testnet-geth-pbss-base-49756165.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-base-49756165.tar.lz4,a6ed0252303b3a18feac05ddd44d2c77,118.35GB
+testnet-geth-pbss-base-49772226.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-base-49772226.tar.lz4,eb3fb6eea86f8f09b9a4f0728f944b56,118.62GB
 testnet-geth-pbss-blocks-42048000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-blocks-42048000.tar.lz4,60e1af49b60e23d795e5375b88b8a613,72.20GB
 testnet-geth-pbss-blocks-21024000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-blocks-21024000.tar.lz4,7378acc5b51c52f34e4e02497c719804,35.94GB
 testnet-geth-pbss-blocks-31536000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-blocks-31536000.tar.lz4,0428e85d9771a5664e0053305ec30e23,35.46GB
-testnet-geth-pbss-blocks-49666165.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-blocks-49666165.tar.lz4,35bcb4f3061a66848bb20ea23f40e29d,25.65GB
+testnet-geth-pbss-blocks-49682226.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-blocks-49682226.tar.lz4,76dcef47356ff443f6dd47f8b91e5fb0,25.70GB
 testnet-geth-pbss-blocks-10512000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-blocks-10512000.tar.lz4,5c4efc11b698d26f1c085b9b4796222d,11.77GB

--- a/dist/testnet-geth-pbss-20250407.csv
+++ b/dist/testnet-geth-pbss-20250407.csv
@@ -1,0 +1,7 @@
+filename,URL,md5,size
+testnet-geth-pbss-base-49756165.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-base-49756165.tar.lz4,a6ed0252303b3a18feac05ddd44d2c77,118.35GB
+testnet-geth-pbss-blocks-42048000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-blocks-42048000.tar.lz4,60e1af49b60e23d795e5375b88b8a613,72.20GB
+testnet-geth-pbss-blocks-21024000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-blocks-21024000.tar.lz4,7378acc5b51c52f34e4e02497c719804,35.94GB
+testnet-geth-pbss-blocks-31536000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-blocks-31536000.tar.lz4,0428e85d9771a5664e0053305ec30e23,35.46GB
+testnet-geth-pbss-blocks-49666165.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-blocks-49666165.tar.lz4,35bcb4f3061a66848bb20ea23f40e29d,25.65GB
+testnet-geth-pbss-blocks-10512000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-blocks-10512000.tar.lz4,5c4efc11b698d26f1c085b9b4796222d,11.77GB


### PR DESCRIPTION
This PR will update the latest testnet snapshot, it supports pruned ancient snapshots now.

### testnet(update every 4 months)

| Snapshot Type   | Snapshot File                                                                               | Total Size | Remark        |
|-----------------|---------------------------------------------------------------------------------------------|------------|---------------|
| Full Snapshot   | [testnet-geth-pbss-20250407]                         | **~300GB** |               |
| Pruned Snapshot | [testnet-geth-pbss-20250407-pruneancient] | **~120GB** | BSC >= v1.5.5 |
