### PR TITLE
update: add latest mainnet snapshot;

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Usage: [usage/legacyfullnode_usage.md](./usage/legacyfullnode_usage.md)
 
 | Snapshot Type   | Snapshot File                                                                               | Total Size | Remark        |
 |-----------------|---------------------------------------------------------------------------------------------|------------|---------------|
-| Full Snapshot   | [mainnet-geth-pbss-20250404](dist/mainnet-geth-pbss-20250404.csv)                           | **~3TB**   |               |
-| Pruned Snapshot | [mainnet-geth-pbss-20250404-pruneancient](dist/mainnet-geth-pbss-20250404-pruneancient.csv) | **~900GB** | BSC >= v1.5.5 |
+| Full Snapshot   | [mainnet-geth-pbss-20250501](dist/mainnet-geth-pbss-20250501.csv)                           | **~3TB**   |               |
+| Pruned Snapshot | [mainnet-geth-pbss-20250501-pruneancient](dist/mainnet-geth-pbss-20250501-pruneancient.csv) | **~900GB** | BSC >= v1.5.5 |
 
 ### testnet(update every 4 months)
 
@@ -58,6 +58,7 @@ bash fetch-snapshot.sh -d -e -c -p --auto-delete -D {download_dir} -E {extract_d
 ### Previous snapshot
 
 - **mainnet**:
+  - [mainnet-geth-pbss-20250404](dist/mainnet-geth-pbss-20250404.csv), [mainnet-geth-pbss-20250404-pruneancient](dist/mainnet-geth-pbss-20250404-pruneancient.csv)
   - [mainnet-geth-pbss-20250310](dist/mainnet-geth-pbss-20250310.csv), [mainnet-geth-pbss-20250310-pruneancient](dist/mainnet-geth-pbss-20250310-pruneancient.csv)
   - [mainnet-geth-pbss-20250208](dist/mainnet-geth-pbss-20250208.csv), [mainnet-geth-pbss-20250208-pruneancient](dist/mainnet-geth-pbss-20250208-pruneancient.csv)
   - [mainnet-geth-pbss-20250104](dist/mainnet-geth-pbss-20250104.csv)

--- a/dist/mainnet-geth-pbss-20250501-pruneancient.csv
+++ b/dist/mainnet-geth-pbss-20250501-pruneancient.csv
@@ -1,0 +1,3 @@
+filename,URL,md5,size
+mainnet-geth-pbss-base-48910772.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-base-48910772.tar.lz4,4484fe973bd62efd111d8b32aaa4e3c6,932.91GB
+mainnet-geth-pbss-blocks-pruneancient-48820772.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-pruneancient-48820772.tar.lz4,4ce491c9c1590fe84c046e53e4082e94,0.00GB

--- a/dist/mainnet-geth-pbss-20250501.csv
+++ b/dist/mainnet-geth-pbss-20250501.csv
@@ -1,0 +1,7 @@
+filename,URL,md5,size
+mainnet-geth-pbss-base-48910772.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-base-48910772.tar.lz4,4484fe973bd62efd111d8b32aaa4e3c6,932.91GB
+mainnet-geth-pbss-blocks-21024000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-21024000.tar.lz4,ef20506070cbe2deb3b0c3c5cae3149d,601.39GB
+mainnet-geth-pbss-blocks-42048000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-42048000.tar.lz4,6a21f55892f6da5f6ca5b77f6c0d88bd,532.23GB
+mainnet-geth-pbss-blocks-31536000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-31536000.tar.lz4,7ed223135e0bb50fdcf625529d89b83c,376.89GB
+mainnet-geth-pbss-blocks-48820772.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-48820772.tar.lz4,d6701f916cbbbed2077c43e53f3df460,328.14GB
+mainnet-geth-pbss-blocks-10512000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-10512000.tar.lz4,3a973854371e526be8dbbce63aad855b,289.91GB


### PR DESCRIPTION
This PR will add the latest mainnet snapshot, which updates every month.


| Snapshot Type   | Snapshot File                                                                               | Total Size | Remark        |
|-----------------|---------------------------------------------------------------------------------------------|------------|---------------|
| Full Snapshot   | [mainnet-geth-pbss-20250501]                      | **~3TB**   |               |
| Pruned Snapshot | [mainnet-geth-pbss-20250501-pruneancient] | **~900GB** | BSC >= v1.5.5 |