### PR TITLE
update: add latest testnet snapshot;

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Usage: [usage/legacyfullnode_usage.md](./usage/legacyfullnode_usage.md)
 
 | Snapshot Type   | Snapshot File                                                                               | Total Size | Remark        |
 |-----------------|---------------------------------------------------------------------------------------------|------------|---------------|
-| Full Snapshot   | [testnet-geth-pbss-20250407](dist/testnet-geth-pbss-20250407.csv)                           | **~300GB** |               |
-| Pruned Snapshot | [testnet-geth-pbss-20250407-pruneancient](dist/testnet-geth-pbss-20250407-pruneancient.csv) | **~120GB** | BSC >= v1.5.5 |
+| Full Snapshot   | [testnet-geth-pbss-20250610](dist/testnet-geth-pbss-20250610.csv)                           | **~300GB** |               |
+| Pruned Snapshot | [testnet-geth-pbss-20250610-pruneancient](dist/testnet-geth-pbss-20250610-pruneancient.csv) | **~120GB** | BSC >= v1.5.5 |
 
 ### Download
 
@@ -63,6 +63,7 @@ bash fetch-snapshot.sh -d -e -c -p --auto-delete -D {download_dir} -E {extract_d
   - [mainnet-geth-pbss-20250404](dist/mainnet-geth-pbss-20250404.csv), [mainnet-geth-pbss-20250404-pruneancient](dist/mainnet-geth-pbss-20250404-pruneancient.csv)
   - [mainnet-geth-pbss-20250310](dist/mainnet-geth-pbss-20250310.csv), [mainnet-geth-pbss-20250310-pruneancient](dist/mainnet-geth-pbss-20250310-pruneancient.csv)
 - **testnet**:
+  - [testnet-geth-pbss-20250407](dist/testnet-geth-pbss-20250407.csv), [testnet-geth-pbss-20250407-pruneancient](dist/testnet-geth-pbss-20250407-pruneancient.csv)
   - [testnet-geth-pbss-20240711.tar.lz4](https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-20240711.tar.lz4)(md5: 64626987189d739bd1a3ee743387f8a6)
 
 ## Source-2: Pruned FullNode(~900GB) & FastNode(~300GB) By 48Club

--- a/dist/testnet-geth-pbss-20250610-pruneancient.csv
+++ b/dist/testnet-geth-pbss-20250610-pruneancient.csv
@@ -1,0 +1,3 @@
+filename,URL,md5,size
+testnet-geth-pbss-base-53990328.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-base-53990328.tar.lz4,5dd29e180d05a3f5e8225431b3382128,124.36GB
+testnet-geth-pbss-blocks-pruneancient-53900328.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-blocks-pruneancient-53900328.tar.lz4,6e78e1cb9fdccaf204965e30b9ed57cf,0.00GB

--- a/dist/testnet-geth-pbss-20250610.csv
+++ b/dist/testnet-geth-pbss-20250610.csv
@@ -1,0 +1,8 @@
+filename,URL,md5,size
+testnet-geth-pbss-base-53990328.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-base-53990328.tar.lz4,5dd29e180d05a3f5e8225431b3382128,124.36GB
+testnet-geth-pbss-blocks-42048000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-blocks-42048000.tar.lz4,60e1af49b60e23d795e5375b88b8a613,72.20GB
+testnet-geth-pbss-blocks-21024000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-blocks-21024000.tar.lz4,7378acc5b51c52f34e4e02497c719804,35.94GB
+testnet-geth-pbss-blocks-31536000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-blocks-31536000.tar.lz4,0428e85d9771a5664e0053305ec30e23,35.46GB
+testnet-geth-pbss-blocks-52560000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-blocks-52560000.tar.lz4,4470dfad7fc649fe652f988b90894422,27.59GB
+testnet-geth-pbss-blocks-10512000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-blocks-10512000.tar.lz4,5c4efc11b698d26f1c085b9b4796222d,11.77GB
+testnet-geth-pbss-blocks-53900328.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/testnet-geth-pbss-blocks-53900328.tar.lz4,03a40551a294bfe94af4490ea5d8c788,5.69GB


### PR DESCRIPTION
This PR will update the latest testnet snapshot, it supports pruned ancient snapshots now.

### testnet(update every 4 months)

| Snapshot Type   | Snapshot File                                                                               | Total Size | Remark        |
|-----------------|---------------------------------------------------------------------------------------------|------------|---------------|
| Full Snapshot   | [testnet-geth-pbss-20250610]                         | **~300GB** |               |
| Pruned Snapshot | [testnet-geth-pbss-20250610-pruneancient] | **~120GB** | BSC >= v1.5.5 |
