### PR TITLE
update: add latest mainnet snapshot;

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Usage: [usage/legacyfullnode_usage.md](./usage/legacyfullnode_usage.md)
 
 | Snapshot Type   | Snapshot File                                                                               | Total Size | Remark        |
 |-----------------|---------------------------------------------------------------------------------------------|------------|---------------|
-| Full Snapshot   | [mainnet-geth-pbss-20250715](dist/mainnet-geth-pbss-20250715.csv)                           | **~3TB**   |               |
-| Pruned Snapshot | [mainnet-geth-pbss-20250715-pruneancient](dist/mainnet-geth-pbss-20250715-pruneancient.csv) | **~900GB** | BSC >= v1.5.5 |
+| Full Snapshot   | [mainnet-geth-pbss-20250806](dist/mainnet-geth-pbss-20250806.csv)                           | **~3TB**   |               |
+| Pruned Snapshot | [mainnet-geth-pbss-20250806-pruneancient](dist/mainnet-geth-pbss-20250806-pruneancient.csv) | **~900GB** | BSC >= v1.5.5 |
 
 ### testnet(update every 4 months)
 
@@ -58,6 +58,7 @@ bash fetch-snapshot.sh -d -e -c -p --auto-delete -D {download_dir} -E {extract_d
 ### Previous snapshot
 
 - **mainnet**:
+  - [mainnet-geth-pbss-20250715](dist/mainnet-geth-pbss-20250715.csv), [mainnet-geth-pbss-20250715-pruneancient](dist/mainnet-geth-pbss-20250715-pruneancient.csv)
   - [mainnet-geth-pbss-20250605](dist/mainnet-geth-pbss-20250605.csv), [mainnet-geth-pbss-20250605-pruneancient](dist/mainnet-geth-pbss-20250605-pruneancient.csv)
   - [mainnet-geth-pbss-20250520](dist/mainnet-geth-pbss-20250520.csv), [mainnet-geth-pbss-20250520-pruneancient](dist/mainnet-geth-pbss-20250520-pruneancient.csv)
   - [mainnet-geth-pbss-20250501](dist/mainnet-geth-pbss-20250501.csv), [mainnet-geth-pbss-20250501-pruneancient](dist/mainnet-geth-pbss-20250501-pruneancient.csv)

--- a/dist/mainnet-geth-pbss-20250806-pruneancient.csv
+++ b/dist/mainnet-geth-pbss-20250806-pruneancient.csv
@@ -1,0 +1,3 @@
+filename,URL,md5,size
+mainnet-geth-pbss-base-56383270.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-base-56383270.tar.lz4,aaf47ac21478ec48d87d6a670cda5a3e,1060.72GB
+mainnet-geth-pbss-blocks-pruneancient-56293270.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-pruneancient-56293270.tar.lz4,ff7a558a1e271ee6bdc795e48aa06097,0.00GB

--- a/dist/mainnet-geth-pbss-20250806.csv
+++ b/dist/mainnet-geth-pbss-20250806.csv
@@ -1,0 +1,8 @@
+filename,URL,md5,size
+mainnet-geth-pbss-base-56383270.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-base-56383270.tar.lz4,aaf47ac21478ec48d87d6a670cda5a3e,1060.72GB
+mainnet-geth-pbss-blocks-52560000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-52560000.tar.lz4,1a3a7f11ab30d6b0b34da2e733ac7d83,647.96GB
+mainnet-geth-pbss-blocks-21024000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-21024000.tar.lz4,ef20506070cbe2deb3b0c3c5cae3149d,601.39GB
+mainnet-geth-pbss-blocks-42048000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-42048000.tar.lz4,6a21f55892f6da5f6ca5b77f6c0d88bd,532.23GB
+mainnet-geth-pbss-blocks-31536000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-31536000.tar.lz4,7ed223135e0bb50fdcf625529d89b83c,376.89GB
+mainnet-geth-pbss-blocks-10512000.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-10512000.tar.lz4,3a973854371e526be8dbbce63aad855b,289.91GB
+mainnet-geth-pbss-blocks-56293270.tar.lz4,https://pub-c0627345c16f47ab858c9469133073a8.r2.dev/mainnet-geth-pbss-blocks-56293270.tar.lz4,279a06766b6924a4cc678c7cd6aa7a0a,168.61GB


### PR DESCRIPTION
This PR will add the latest mainnet snapshot, which updates every month.


| Snapshot Type   | Snapshot File                                                                               | Total Size | Remark        |
|-----------------|---------------------------------------------------------------------------------------------|------------|---------------|
| Full Snapshot   | [mainnet-geth-pbss-20250806]                      | **~3TB**   |               |
| Pruned Snapshot | [mainnet-geth-pbss-20250806-pruneancient] | **~1000GB** | BSC >= v1.5.5 |